### PR TITLE
Add flexible expense analytics script

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,20 @@ python expense_analytics.py --dimensions month category
 ```
 
 The script prints a table with the aggregated totals and displays a simple bar chart for a quick visual overview.
+
+## Flexible Expense Analytics
+
+`expense_analytics_flexible.py` provides more control over how the data is grouped and filtered.
+
+Example usages:
+
+```bash
+# total spend by quarter and category for transactions over $100
+python expense_analytics_flexible.py --dimensions quarter category --min-transaction 100
+
+# monthly totals per merchant only showing groups above $500
+python expense_analytics_flexible.py --dimensions month merchant --min-total 500
+```
+
+Available dimensions: `day`, `month`, `quarter`, `year`, `category`, `merchant`.
+Use `--min-transaction` and `--max-transaction` to filter transactions by amount and `--min-total` to show only groups exceeding a threshold.

--- a/expense_analytics_flexible.py
+++ b/expense_analytics_flexible.py
@@ -1,0 +1,113 @@
+import argparse
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def load_data(csv_path: str) -> pd.DataFrame:
+    """Load the credit card statement CSV and add time dimensions."""
+    df = pd.read_csv(
+        csv_path,
+        parse_dates=["Transaction Date", "Posting Date"],
+    )
+    df["Amount"] = df["Amount"].astype(float)
+    df["Day"] = df["Transaction Date"].dt.date.astype(str)
+    df["Month"] = df["Transaction Date"].dt.to_period("M").astype(str)
+    df["Quarter"] = df["Transaction Date"].dt.to_period("Q").astype(str)
+    df["Year"] = df["Transaction Date"].dt.year.astype(str)
+    return df
+
+
+def filter_transactions(
+    df: pd.DataFrame,
+    min_amount: float | None = None,
+    max_amount: float | None = None,
+) -> pd.DataFrame:
+    """Filter transactions by amount thresholds."""
+    if min_amount is not None:
+        df = df[df["Amount"] >= min_amount]
+    if max_amount is not None:
+        df = df[df["Amount"] <= max_amount]
+    return df
+
+
+def aggregate_spending(
+    df: pd.DataFrame,
+    dimensions: list[str],
+    min_total: float | None = None,
+) -> pd.DataFrame:
+    """Aggregate spending along the requested dimensions."""
+    available_dims = {
+        "day": "Day",
+        "month": "Month",
+        "quarter": "Quarter",
+        "year": "Year",
+        "category": "Category",
+        "merchant": "Merchant",
+    }
+    cols = [available_dims[d] for d in dimensions]
+    summary = df.groupby(cols)["Amount"].sum().reset_index()
+    if min_total is not None:
+        summary = summary[summary["Amount"] >= min_total]
+    return summary
+
+
+def display(summary: pd.DataFrame, dimensions: list[str]) -> None:
+    """Pretty-print the summary and plot a simple chart."""
+    print("\nSpending Summary:\n")
+    print(summary.to_string(index=False))
+
+    if len(dimensions) == 1:
+        summary.plot.bar(x=dimensions[0], y="Amount", legend=False)
+        plt.ylabel("Total Spend ($)")
+        plt.tight_layout()
+        plt.show()
+    elif len(dimensions) == 2:
+        pivot = summary.pivot(index=dimensions[0], columns=dimensions[1], values="Amount")
+        pivot.plot(kind="bar", stacked=True)
+        plt.ylabel("Total Spend ($)")
+        plt.tight_layout()
+        plt.show()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Analyze credit card spending with flexible dimensions")
+    parser.add_argument(
+        "--csv",
+        default="credit_card_statements.csv",
+        help="Path to credit_card_statements.csv",
+    )
+    parser.add_argument(
+        "--dimensions",
+        nargs="+",
+        default=["month"],
+        choices=["day", "month", "quarter", "year", "category", "merchant"],
+        help="Dimensions to group by",
+    )
+    parser.add_argument(
+        "--min-transaction",
+        type=float,
+        default=None,
+        help="Filter out transactions below this amount",
+    )
+    parser.add_argument(
+        "--max-transaction",
+        type=float,
+        default=None,
+        help="Filter out transactions above this amount",
+    )
+    parser.add_argument(
+        "--min-total",
+        type=float,
+        default=None,
+        help="Only display groups with totals above this amount",
+    )
+    args = parser.parse_args()
+
+    df = load_data(args.csv)
+    df = filter_transactions(df, args.min_transaction, args.max_transaction)
+    summary = aggregate_spending(df, args.dimensions, args.min_total)
+    display(summary, args.dimensions)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `expense_analytics_flexible.py` to group spending by additional dimensions and filter by thresholds
- document new script usage in README

## Testing
- `python expense_analytics_flexible.py --dimensions month category --min-transaction 100 --min-total 2000` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685cb581be9483328c2bc9afca84c2c9