### PR TITLE
Add chart type option for analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ python expense_analytics.py --dimensions category
 python expense_analytics.py --dimensions month category
 ```
 
-The script prints a table with the aggregated totals and displays a simple bar chart for a quick visual overview.
+The script prints a table with the aggregated totals and displays a chart for a quick visual overview. Use `--chart-type` to choose between `bar`, `stacked`, or `pie` styles.
 
 ## Flexible Expense Analytics
 
@@ -54,6 +54,8 @@ python expense_analytics_flexible.py --dimensions quarter category --min-transac
 # monthly totals per merchant only showing groups above $500
 python expense_analytics_flexible.py --dimensions month merchant --min-total 500
 ```
+
+Both analytics scripts accept `--chart-type` to control the visualization style.
 
 Available dimensions: `day`, `month`, `quarter`, `year`, `category`, `merchant`.
 Use `--min-transaction` and `--max-transaction` to filter transactions by amount and `--min-total` to show only groups exceeding a threshold.

--- a/expense_analytics.py
+++ b/expense_analytics.py
@@ -22,20 +22,25 @@ def aggregate_spending(df: pd.DataFrame, dimensions: list[str]) -> pd.DataFrame:
     return summary
 
 
-def display(summary: pd.DataFrame, dimensions: list[str]) -> None:
-    """Pretty-print the summary and plot a simple chart."""
+def display(summary: pd.DataFrame, dimensions: list[str], chart_type: str) -> None:
+    """Pretty-print the summary and plot a chart."""
     print("\nSpending Summary:\n")
     print(summary.to_string(index=False))
 
-    # Basic bar chart for a quick visual
     if len(dimensions) == 1:
-        summary.plot.bar(x=dimensions[0], y="Amount", legend=False)
+        if chart_type == "pie":
+            summary.set_index(dimensions[0])["Amount"].plot.pie(autopct="%.1f%%")
+        else:  # bar
+            summary.plot.bar(x=dimensions[0], y="Amount", legend=False)
         plt.ylabel("Total Spend ($)")
         plt.tight_layout()
         plt.show()
     elif len(dimensions) == 2:
         pivot = summary.pivot(index=dimensions[0], columns=dimensions[1], values="Amount")
-        pivot.plot(kind="bar", stacked=True)
+        if chart_type == "stacked":
+            pivot.plot(kind="bar", stacked=True)
+        else:  # bar
+            pivot.plot(kind="bar")
         plt.ylabel("Total Spend ($)")
         plt.tight_layout()
         plt.show()
@@ -55,11 +60,17 @@ def main() -> None:
         choices=["month", "category"],
         help="Dimensions to group by (month, category)",
     )
+    parser.add_argument(
+        "--chart-type",
+        default="bar",
+        choices=["bar", "pie", "stacked"],
+        help="Type of chart to display",
+    )
     args = parser.parse_args()
 
     df = load_data(args.csv)
     summary = aggregate_spending(df, args.dimensions)
-    display(summary, args.dimensions)
+    display(summary, args.dimensions, args.chart_type)
 
 
 if __name__ == "__main__":

--- a/expense_analytics_flexible.py
+++ b/expense_analytics_flexible.py
@@ -51,19 +51,25 @@ def aggregate_spending(
     return summary
 
 
-def display(summary: pd.DataFrame, dimensions: list[str]) -> None:
-    """Pretty-print the summary and plot a simple chart."""
+def display(summary: pd.DataFrame, dimensions: list[str], chart_type: str) -> None:
+    """Pretty-print the summary and plot a chart."""
     print("\nSpending Summary:\n")
     print(summary.to_string(index=False))
 
     if len(dimensions) == 1:
-        summary.plot.bar(x=dimensions[0], y="Amount", legend=False)
+        if chart_type == "pie":
+            summary.set_index(dimensions[0])["Amount"].plot.pie(autopct="%.1f%%")
+        else:  # bar
+            summary.plot.bar(x=dimensions[0], y="Amount", legend=False)
         plt.ylabel("Total Spend ($)")
         plt.tight_layout()
         plt.show()
     elif len(dimensions) == 2:
         pivot = summary.pivot(index=dimensions[0], columns=dimensions[1], values="Amount")
-        pivot.plot(kind="bar", stacked=True)
+        if chart_type == "stacked":
+            pivot.plot(kind="bar", stacked=True)
+        else:  # bar
+            pivot.plot(kind="bar")
         plt.ylabel("Total Spend ($)")
         plt.tight_layout()
         plt.show()
@@ -101,12 +107,18 @@ def main() -> None:
         default=None,
         help="Only display groups with totals above this amount",
     )
+    parser.add_argument(
+        "--chart-type",
+        default="bar",
+        choices=["bar", "pie", "stacked"],
+        help="Type of chart to display",
+    )
     args = parser.parse_args()
 
     df = load_data(args.csv)
     df = filter_transactions(df, args.min_transaction, args.max_transaction)
     summary = aggregate_spending(df, args.dimensions, args.min_total)
-    display(summary, args.dimensions)
+    display(summary, args.dimensions, args.chart_type)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend analytics scripts with `--chart-type` arg
- allow `bar`, `pie`, and `stacked` charts
- document usage in README

## Testing
- `python -m py_compile expense_analytics.py expense_analytics_flexible.py`
- ❌ `python expense_analytics.py --dimensions month --chart-type pie` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685cb895bddc8332a7e3817ffbd85dc0