### PR TITLE
Add RateGuard Phase 1 backend prototype with core workflows and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,14 @@ python -m http.server 8000
 ```
 
 For requirement discovery prompts, see `office_chore_app/REQUIREMENTS_QUESTIONS.md`.
+
+## RateGuard Phase 1 Prototype
+
+A new backend prototype for the RateGuard insurance monitoring platform is included in `rateguard/`.
+
+Run:
+
+```bash
+python -m unittest discover -s rateguard/tests -v
+python -m rateguard.app.main
+```

--- a/rateguard/README.md
+++ b/rateguard/README.md
@@ -1,0 +1,63 @@
+# RateGuard Phase 1 (Software Blueprint + Working Backend Skeleton)
+
+This folder contains a production-oriented starter implementation of **RateGuard** aligned to the provided requirements:
+
+- Single-tenant platform model
+- Ohio-first personal lines focus
+- STP-first workflows with referral escalation
+- Event-driven core behaviors
+- Subscription-gated quoting and binding
+- Transparent ranking output with weighted component scores
+
+## Implemented Modules
+
+### 1) Identity + Onboarding
+- Social-provider constrained onboarding payload
+- MFA code validation shape
+- User + household creation placeholder
+- Extraction confidence check with automatic referral trigger
+
+### 2) Quote Orchestration
+- Subscription-state validation
+- Ohio-only validation for Phase 1
+- Parallel simulated carrier rating calls
+- Quote normalization to canonical model
+- Weighted ranking engine with versioned model ID
+- QuoteGenerated event emission
+
+### 3) Referral Engine (Skill-Based Routing)
+- Referral case creation with skill tags
+- Producer assignment based on skills
+- Immutable event emission and case persistence
+
+### 4) STP Bind Flow
+- BindRequested and BindConfirmed events
+- Policy activation and issued document references
+- Commission ledger event emission
+
+### 5) Renewal Recommendation
+- Current vs market premium comparison
+- Switch/retain recommendation
+- Savings estimate and event emission
+
+## Code Structure
+
+- `app/models.py`: domain entities and request/response models
+- `app/services.py`: workflow services and orchestration logic
+- `app/main.py`: app façade and end-to-end demo execution
+- `tests/test_workflows.py`: regression tests for core workflow paths
+
+## Run Locally
+
+```bash
+python -m unittest discover -s rateguard/tests -v
+python -m rateguard.app.main
+```
+
+## Notes for Next Iteration
+
+- Replace in-memory store with PostgreSQL + object storage.
+- Add message queue and dead-letter queue for carrier timeouts.
+- Add OAuth2/JWT and role-based auth middleware.
+- Integrate real carrier adapters + vendor integrations.
+- Add feature flag controls by state/product/carrier.

--- a/rateguard/app/main.py
+++ b/rateguard/app/main.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import asdict
+
+from .models import BindRequest, OnboardingRequest, ProductLine, QuoteRequest, RiskModel
+from .services import (
+    BindService,
+    CarrierAdapter,
+    EventBus,
+    InMemoryStore,
+    OnboardingService,
+    QuoteOrchestrator,
+    ReferralService,
+    RenewalService,
+)
+
+
+class RateGuardApplication:
+    """Facade for RateGuard Phase 1 workflows.
+
+    This keeps interfaces close to future API endpoints while staying dependency-free.
+    """
+
+    def __init__(self) -> None:
+        self.store = InMemoryStore()
+        self.event_bus = EventBus(events=[])
+        self.onboarding = OnboardingService(self.store, self.event_bus)
+        self.quote_orchestrator = QuoteOrchestrator(
+            self.store,
+            self.event_bus,
+            adapters=[
+                CarrierAdapter("Buckeye Mutual", 0.92, (0.05, 0.2)),
+                CarrierAdapter("Lakefront Casualty", 0.86, (0.05, 0.2)),
+                CarrierAdapter("River Valley Insurance", 0.8, (0.05, 0.2)),
+            ],
+        )
+        self.referrals = ReferralService(self.store, self.event_bus)
+        self.binding = BindService(self.store, self.event_bus)
+        self.renewals = RenewalService(self.event_bus)
+
+    async def run_demo(self) -> dict:
+        onboarding = self.onboarding.onboard(
+            OnboardingRequest(
+                email="demo@rateguard.io",
+                social_provider="google",
+                mfa_code="123456",
+                household_name="Doe Household",
+                extraction_confidence=0.93,
+            )
+        )
+        quotes = await self.quote_orchestrator.generate_quotes(
+            QuoteRequest(
+                user_id=onboarding.user.user_id,
+                risk=RiskModel(product_line=ProductLine.AUTO),
+            )
+        )
+        selected = quotes.quotes[0]
+        bind = self.binding.bind(onboarding.user.user_id, selected.quote_id)
+        recommendation = self.renewals.recommend(onboarding.user.user_id, bind.policy_id, 1800, selected.annual_premium)
+        return {
+            "onboarding": asdict(onboarding),
+            "quotes": [asdict(q) for q in quotes.quotes],
+            "bind": asdict(bind),
+            "renewal": asdict(recommendation),
+            "events": self.event_bus.events,
+        }
+
+
+if __name__ == "__main__":
+    output = asyncio.run(RateGuardApplication().run_demo())
+    print(output)

--- a/rateguard/app/models.py
+++ b/rateguard/app/models.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any
+
+
+class SubscriptionState(str, Enum):
+    ACTIVE = "Active"
+    PAST_DUE = "PastDue"
+    GRACE = "Grace"
+    SUSPENDED = "Suspended"
+    CANCELED = "Canceled"
+
+
+class ApplicationState(str, Enum):
+    DRAFT = "Draft"
+    QUOTED = "Quoted"
+    APPLICATION = "Application"
+    REFERRAL = "Referral"
+    APPROVED = "Approved"
+    BOUND = "Bound"
+    ISSUED = "Issued"
+    ACTIVE = "Active"
+    EXPIRED = "Expired"
+
+
+class ProductLine(str, Enum):
+    AUTO = "auto"
+    HOME = "home"
+    RENTERS = "renters"
+    UMBRELLA = "umbrella"
+
+
+@dataclass
+class User:
+    user_id: str
+    email: str
+    household_id: str
+    subscription_state: SubscriptionState = SubscriptionState.ACTIVE
+
+
+@dataclass
+class OnboardingRequest:
+    email: str
+    social_provider: str
+    mfa_code: str
+    household_name: str
+    extraction_confidence: float
+
+    def validate(self) -> None:
+        if self.social_provider not in {"google", "apple"}:
+            raise ValueError("social_provider must be google or apple")
+        if len(self.mfa_code) != 6 or not self.mfa_code.isdigit():
+            raise ValueError("mfa_code must be a 6-digit string")
+        if not 0.0 <= self.extraction_confidence <= 1.0:
+            raise ValueError("extraction_confidence must be between 0 and 1")
+
+
+@dataclass
+class OnboardingResponse:
+    user: User
+    referred_for_review: bool
+    events: list[str]
+
+
+@dataclass
+class RiskModel:
+    product_line: ProductLine
+    state: str = "OH"
+    limits: dict[str, Any] = field(default_factory=dict)
+    deductible: int | None = None
+
+
+@dataclass
+class QuoteRequest:
+    user_id: str
+    risk: RiskModel
+
+
+@dataclass
+class QuoteScore:
+    price: float
+    coverage_quality: float
+    carrier_strength: float
+    weights: dict[str, float]
+    final_score: float
+    model_id: str
+
+
+@dataclass
+class Quote:
+    quote_id: str
+    carrier: str
+    monthly_premium: float
+    annual_premium: float
+    coverage_summary: dict[str, Any]
+    tier: str
+    score: QuoteScore
+    generated_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class QuoteBundle:
+    request_id: str
+    user_id: str
+    quotes: list[Quote]
+    ranking_version: str
+
+
+@dataclass
+class BindRequest:
+    user_id: str
+    quote_id: str
+
+
+@dataclass
+class BindResponse:
+    policy_id: str
+    status: ApplicationState
+    documents: list[str]
+    events: list[str]
+
+
+@dataclass
+class ReferralCase:
+    case_id: str
+    user_id: str
+    reason: str
+    skill_tags: list[str]
+    assigned_producer: str
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class RenewalRecommendation:
+    user_id: str
+    current_policy_id: str
+    suggested_action: str
+    estimated_savings: float
+    generated_at: datetime = field(default_factory=datetime.utcnow)

--- a/rateguard/app/services.py
+++ b/rateguard/app/services.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import asyncio
+import random
+from dataclasses import dataclass
+from typing import Iterable
+from uuid import uuid4
+
+from .models import (
+    ApplicationState,
+    BindResponse,
+    OnboardingRequest,
+    OnboardingResponse,
+    Quote,
+    QuoteBundle,
+    QuoteRequest,
+    QuoteScore,
+    ReferralCase,
+    RenewalRecommendation,
+    SubscriptionState,
+    User,
+)
+
+
+@dataclass
+class EventBus:
+    events: list[str]
+
+    def emit(self, event_name: str, **payload: str) -> None:
+        self.events.append(f"{event_name}:{payload}")
+
+
+class InMemoryStore:
+    def __init__(self) -> None:
+        self.users: dict[str, User] = {}
+        self.quotes: dict[str, Quote] = {}
+        self.policies: dict[str, dict] = {}
+        self.referrals: dict[str, ReferralCase] = {}
+
+
+class OnboardingService:
+    def __init__(self, store: InMemoryStore, event_bus: EventBus, threshold: float = 0.8) -> None:
+        self.store = store
+        self.event_bus = event_bus
+        self.threshold = threshold
+
+    def onboard(self, request: OnboardingRequest) -> OnboardingResponse:
+        request.validate()
+        user_id = f"usr_{uuid4().hex[:10]}"
+        user = User(
+            user_id=user_id,
+            email=request.email,
+            household_id=f"hh_{uuid4().hex[:8]}",
+            subscription_state=SubscriptionState.ACTIVE,
+        )
+        self.store.users[user.user_id] = user
+        self.event_bus.emit("SubscriptionUpdated", user_id=user.user_id, state=user.subscription_state.value)
+
+        referred = request.extraction_confidence < self.threshold
+        if referred:
+            self.event_bus.emit("ReferralTriggered", user_id=user.user_id, reason="LowExtractionConfidence")
+
+        return OnboardingResponse(user=user, referred_for_review=referred, events=self.event_bus.events[-2:])
+
+
+class CarrierAdapter:
+    def __init__(self, name: str, strength: float, jitter: tuple[float, float]) -> None:
+        self.name = name
+        self.strength = strength
+        self.jitter = jitter
+
+    async def quote(self, annual_baseline: float) -> dict:
+        await asyncio.sleep(random.uniform(*self.jitter))
+        multiplier = random.uniform(0.85, 1.25)
+        annual = round(annual_baseline * multiplier, 2)
+        return {
+            "carrier": self.name,
+            "annual_premium": annual,
+            "monthly_premium": round(annual / 12, 2),
+            "coverage": {
+                "bodily_injury": "100/300",
+                "property_damage": "100",
+                "comprehensive": True,
+            },
+            "carrier_strength": self.strength,
+        }
+
+
+class QuoteOrchestrator:
+    def __init__(self, store: InMemoryStore, event_bus: EventBus, adapters: Iterable[CarrierAdapter]) -> None:
+        self.store = store
+        self.event_bus = event_bus
+        self.adapters = list(adapters)
+        self.score_weights = {"price": 0.5, "coverage_quality": 0.25, "carrier_strength": 0.25}
+        self.scoring_model_id = "rank-v1"
+
+    async def generate_quotes(self, request: QuoteRequest) -> QuoteBundle:
+        user = self.store.users.get(request.user_id)
+        if not user or user.subscription_state not in {SubscriptionState.ACTIVE, SubscriptionState.GRACE}:
+            raise ValueError("Subscription is not active")
+        if request.risk.state != "OH":
+            raise ValueError("Phase 1 supports Ohio policies only")
+
+        self.event_bus.emit("QuoteRequested", user_id=request.user_id, line=request.risk.product_line.value)
+
+        baseline = 1600.0 if request.risk.product_line.value == "auto" else 1200.0
+        responses = await asyncio.gather(*(adapter.quote(baseline) for adapter in self.adapters))
+
+        raw_quotes = [self._to_quote(response) for response in responses]
+        ranked = sorted(raw_quotes, key=lambda item: item.score.final_score, reverse=True)
+
+        for quote in ranked:
+            self.store.quotes[quote.quote_id] = quote
+
+        request_id = f"qr_{uuid4().hex[:10]}"
+        bundle = QuoteBundle(
+            request_id=request_id,
+            user_id=request.user_id,
+            quotes=ranked,
+            ranking_version=self.scoring_model_id,
+        )
+        self.event_bus.emit("QuoteGenerated", request_id=request_id, quote_count=str(len(ranked)))
+        return bundle
+
+    def _to_quote(self, carrier_data: dict) -> Quote:
+        annual = carrier_data["annual_premium"]
+        price_score = max(0.0, min(1.0, 1 - ((annual - 900) / 1800)))
+        coverage_quality = 0.85
+        carrier_strength = carrier_data["carrier_strength"]
+        score = (
+            self.score_weights["price"] * price_score
+            + self.score_weights["coverage_quality"] * coverage_quality
+            + self.score_weights["carrier_strength"] * carrier_strength
+        )
+
+        tier = "Gold" if carrier_strength >= 0.9 else "Silver" if carrier_strength >= 0.8 else "Bronze"
+
+        return Quote(
+            quote_id=f"qt_{uuid4().hex[:10]}",
+            carrier=carrier_data["carrier"],
+            monthly_premium=carrier_data["monthly_premium"],
+            annual_premium=annual,
+            coverage_summary=carrier_data["coverage"],
+            tier=tier,
+            score=QuoteScore(
+                price=round(price_score, 4),
+                coverage_quality=coverage_quality,
+                carrier_strength=carrier_strength,
+                weights=self.score_weights,
+                final_score=round(score, 4),
+                model_id=self.scoring_model_id,
+            ),
+        )
+
+
+class ReferralService:
+    def __init__(self, store: InMemoryStore, event_bus: EventBus) -> None:
+        self.store = store
+        self.event_bus = event_bus
+
+    def create_referral(self, user_id: str, reason: str, skill_tags: list[str]) -> ReferralCase:
+        assigned = "producer_oh_auto_senior" if "high_limit" in skill_tags else "producer_oh_general"
+        case = ReferralCase(
+            case_id=f"ref_{uuid4().hex[:10]}",
+            user_id=user_id,
+            reason=reason,
+            skill_tags=skill_tags,
+            assigned_producer=assigned,
+        )
+        self.store.referrals[case.case_id] = case
+        self.event_bus.emit("ReferralTriggered", case_id=case.case_id, producer=assigned)
+        return case
+
+
+class BindService:
+    def __init__(self, store: InMemoryStore, event_bus: EventBus) -> None:
+        self.store = store
+        self.event_bus = event_bus
+
+    def bind(self, user_id: str, quote_id: str) -> BindResponse:
+        user = self.store.users.get(user_id)
+        quote = self.store.quotes.get(quote_id)
+        if not user or not quote:
+            raise ValueError("User or quote not found")
+        if user.subscription_state != SubscriptionState.ACTIVE:
+            raise ValueError("Subscription must be active to bind")
+
+        self.event_bus.emit("BindRequested", user_id=user_id, quote_id=quote_id)
+
+        policy_id = f"pl_{uuid4().hex[:12]}"
+        docs = [f"{policy_id}_declaration.pdf", f"{policy_id}_id_card.pdf"]
+        self.store.policies[policy_id] = {
+            "user_id": user_id,
+            "quote_id": quote_id,
+            "status": ApplicationState.ACTIVE,
+            "documents": docs,
+        }
+
+        self.event_bus.emit("BindConfirmed", user_id=user_id, policy_id=policy_id)
+        self.event_bus.emit("CommissionRecorded", policy_id=policy_id, quote_id=quote_id)
+        return BindResponse(policy_id=policy_id, status=ApplicationState.ACTIVE, documents=docs, events=self.event_bus.events[-3:])
+
+
+class RenewalService:
+    def __init__(self, event_bus: EventBus) -> None:
+        self.event_bus = event_bus
+
+    def recommend(self, user_id: str, current_policy_id: str, current_annual: float, best_market_annual: float) -> RenewalRecommendation:
+        savings = round(max(0.0, current_annual - best_market_annual), 2)
+        action = "Switch" if savings > 100 else "Retain"
+        recommendation = RenewalRecommendation(
+            user_id=user_id,
+            current_policy_id=current_policy_id,
+            suggested_action=action,
+            estimated_savings=savings,
+        )
+        self.event_bus.emit("RenewalRecommendationGenerated", policy_id=current_policy_id, action=action)
+        return recommendation

--- a/rateguard/tests/test_workflows.py
+++ b/rateguard/tests/test_workflows.py
@@ -1,0 +1,62 @@
+import asyncio
+import unittest
+
+from rateguard.app.models import OnboardingRequest, ProductLine, QuoteRequest, RiskModel
+from rateguard.app.services import (
+    BindService,
+    CarrierAdapter,
+    EventBus,
+    InMemoryStore,
+    OnboardingService,
+    QuoteOrchestrator,
+    RenewalService,
+)
+
+
+class WorkflowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.store = InMemoryStore()
+        self.events = EventBus(events=[])
+        self.onboarding = OnboardingService(self.store, self.events)
+        self.orchestrator = QuoteOrchestrator(
+            self.store,
+            self.events,
+            [
+                CarrierAdapter("A", 0.9, (0, 0)),
+                CarrierAdapter("B", 0.85, (0, 0)),
+                CarrierAdapter("C", 0.8, (0, 0)),
+            ],
+        )
+        self.binding = BindService(self.store, self.events)
+        self.renewal = RenewalService(self.events)
+
+    def test_onboarding_to_quote_to_bind(self) -> None:
+        onboarded = self.onboarding.onboard(
+            OnboardingRequest(
+                email="user@example.com",
+                social_provider="google",
+                mfa_code="123456",
+                household_name="Smith",
+                extraction_confidence=0.95,
+            )
+        )
+        self.assertFalse(onboarded.referred_for_review)
+
+        bundle = asyncio.run(
+            self.orchestrator.generate_quotes(
+                QuoteRequest(user_id=onboarded.user.user_id, risk=RiskModel(product_line=ProductLine.AUTO))
+            )
+        )
+        self.assertGreaterEqual(len(bundle.quotes), 3)
+
+        bound = self.binding.bind(onboarded.user.user_id, bundle.quotes[0].quote_id)
+        self.assertEqual(bound.status.value, "Active")
+
+    def test_renewal_recommendation(self) -> None:
+        recommendation = self.renewal.recommend("u1", "p1", current_annual=1800, best_market_annual=1450)
+        self.assertEqual(recommendation.suggested_action, "Switch")
+        self.assertEqual(recommendation.estimated_savings, 350)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Provide a runnable Phase 1 backend prototype for RateGuard that encodes the single-tenant, Ohio-first, STP-first architecture and core business workflows so downstream teams can iterate on adapters and persistence.
- Ensure the prototype runs in constrained environments without third-party runtime requirements by using the standard library for domain models and testability.

### Description
- Added a new `rateguard/` backend prototype implementing domain models, an in-memory store, an `EventBus`, and services for onboarding (with extraction-confidence referral trigger), quote orchestration (parallel carrier simulation, Ohio + subscription gating, weighted ranking with model ID), referral routing, STP bind flow (policy issuance events and docs), and renewal recommendations (`rateguard/app/models.py`, `rateguard/app/services.py`).
- Introduced a lightweight application facade `RateGuardApplication` that wires services and provides an end-to-end demo run for onboarding → quote → bind → renewal (`rateguard/app/main.py`).
- Converted models to `dataclasses` (stdlib) to avoid external dependencies and keep the prototype runnable in constrained/networked environments, and included a README describing next steps and architecture (`rateguard/README.md` and updated root `README.md`).
- Added regression tests that exercise onboarding → quote → bind and renewal recommendation flows using `unittest` (`rateguard/tests/test_workflows.py`).

### Testing
- Ran unit tests with `python -m unittest discover -s rateguard/tests -v`, and all tests passed (2 tests, OK).
- Executed the end-to-end demo via `python -m rateguard.app.main`, which completed and printed the generated onboarding, quotes, bind, renewal recommendation, and emitted events.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a26fd3cf4883328347a8ecbcae35ce)